### PR TITLE
Fixes error: ‘restart’ undeclared

### DIFF
--- a/patches/restoreafterrestart/dwm-restoreafterrestart-20220709-d3f93c7.diff
+++ b/patches/restoreafterrestart/dwm-restoreafterrestart-20220709-d3f93c7.diff
@@ -80,6 +80,7 @@ index 74cec7e..76b40a2 100644
  void
  quit(const Arg *arg)
  {
++	int restart = 0;
  	if(arg->i) restart = 1;
  	running = 0;
 +


### PR DESCRIPTION
`restart` variable is undeclared and is breaking `dwm` on the patch.
I have declared a variable `restart` with an initial value of `0`, which fixes the issue.